### PR TITLE
Enable Bad share rejection message

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -198,8 +198,8 @@ var StratumClient = function(options){
                 if (!considerBan(result)){
                     sendJson({
                         id: message.id,
-                        result: true,
-                        error: null
+                        result: result,
+                        error: error
                     });
                 }
             }


### PR DESCRIPTION
It was turned off before the Verus days, no need for it to be off