### PR TITLE
Fix nTime calculation (#44)

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -203,13 +203,25 @@ var JobManager = module.exports = function JobManager(options) {
             return shareError([20, 'incorrect size of ntime']);
         }
 
-        //console.log('processShare ck2')
+        let nTimeInt = parseInt(nTime.substr(6, 2) + nTime.substr(4, 2) + nTime.substr(2, 2) + nTime.substr(0, 2), 16)
 
-        var nTimeInt = parseInt(util.reverseBuffer(new Buffer(nTime, 'hex')), 16);
-        if (nTimeInt < job.rpcData.curtime || nTimeInt > submitTime + 7200) {
-            console.log('ntime out of range');
-            return shareError([20, 'ntime out of range']);
+        if (Number.isNaN(nTimeInt)) {
+            // console.log('Invalid nTime: ', nTimeInt, nTime)
+            return shareError([20, 'invalid ntime'])
         }
+
+        if (nTimeInt < job.rpcData.curtime || nTimeInt > submitTime + 7200) {
+            // console.log('ntime out of range !(', submitTime + 7200, '<', nTimeInt, '<', job.rpcData.curtime, ') original: ', nTime)
+            return shareError([20, 'ntime out of range'])
+        }
+
+        // console.log(
+        //     'ntime', nTime,
+        //     'buffered', util.reverseBuffer(new Buffer(nTime, 'hex')),
+        //     'inted', parseInt(util.reverseBuffer(new Buffer(nTime, 'hex')).toString('hex'), 16),
+        //     'nTimeInt', nTimeInt,
+        //     '(', submitTime + 7200, '<', nTimeInt, '<', job.rpcData.curtime, ')'
+        // )
 
         //console.log('processShare ck3')
 
@@ -244,8 +256,6 @@ var JobManager = module.exports = function JobManager(options) {
             console.log('invalid hex in extraNonce2');
             return shareError([20, 'invalid hex in extraNonce2']);
         }
-
-        //console.log('processShare ck4')
 
         if (!job.registerSubmit(nonce, soln)) {
             return shareError([22, 'duplicate share']);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,104 +1,106 @@
-var crypto = require('crypto');
+const crypto = require('crypto')
 
-var base58 = require('base58-native');
-var bignum = require('bignum');
+const base58 = require('base58-native')
+const bignum = require('bignum')
 
 
-exports.addressFromEx = function (exAddress, ripdm160Key) {
+exports.addressFromEx = (exAddress, ripdm160Key) => {
     try {
-        var versionByte = exports.getVersionByte(exAddress);
-        var addrBase = new Buffer.concat([versionByte, new Buffer(ripdm160Key, 'hex')]);
-        var checksum = exports.sha256d(addrBase).slice(0, 4);
-        var address = new Buffer.concat([addrBase, checksum]);
-        return base58.encode(address);
+        let versionByte = exports.getVersionByte(exAddress)
+        let addrBase = new Buffer.concat([versionByte, new Buffer(ripdm160Key, 'hex')])
+        let checksum = exports.sha256d(addrBase).slice(0, 4)
+        let address = new Buffer.concat([addrBase, checksum])
+        return base58.encode(address)
+    } catch (e) {
+        return null
     }
-    catch (e) {
-        return null;
+}
+
+
+exports.getVersionByte = addr => {
+    return base58.decode(addr).slice(0, 1)
+}
+
+exports.sha256 = buffer => {
+    let hash1 = crypto.createHash('sha256')
+    hash1.update(buffer)
+    return hash1.digest()
+}
+
+exports.sha256d = buffer => {
+    return exports.sha256(exports.sha256(buffer))
+}
+
+exports.reverseBuffer = buff => {
+    let reversed = new Buffer(buff.length)
+    for (let i = buff.length - 1; i >= 0; i--) {
+        reversed[buff.length - i - 1] = buff[i]
     }
-};
 
+    return reversed
+}
 
-exports.getVersionByte = function (addr) {
-    var versionByte = base58.decode(addr).slice(0, 1);
-    return versionByte;
-};
+exports.reverseHex = hex => {
+    return exports.reverseBuffer(
+        new Buffer(hex, 'hex')
+    ).toString('hex')
+}
 
-exports.sha256 = function (buffer) {
-    var hash1 = crypto.createHash('sha256');
-    hash1.update(buffer);
-    return hash1.digest();
-};
+exports.reverseByteOrder = buff => {
+    for (let i = 0; i < 8; i++) {
+        buff.writeUInt32LE(buff.readUInt32BE(i * 4), i * 4)
+    }
 
-exports.sha256d = function (buffer) {
-    return exports.sha256(exports.sha256(buffer));
-};
+    return exports.reverseBuffer(buff)
+}
 
-exports.reverseBuffer = function (buff) {
-    var reversed = new Buffer(buff.length);
-    for (var i = buff.length - 1; i >= 0; i--)
-        reversed[buff.length - i - 1] = buff[i];
-    return reversed;
-};
-
-exports.reverseHex = function (hex) {
-    return exports.reverseBuffer(new Buffer(hex, 'hex')).toString('hex');
-};
-
-exports.reverseByteOrder = function (buff) {
-    for (var i = 0; i < 8; i++) buff.writeUInt32LE(buff.readUInt32BE(i * 4), i * 4);
-    return exports.reverseBuffer(buff);
-};
-
-exports.uint256BufferFromHash = function (hex) {
-
-    var fromHex = new Buffer(hex, 'hex');
+exports.uint256BufferFromHash = hex => {
+    let fromHex = new Buffer(hex, 'hex')
 
     if (fromHex.length != 32) {
-        var empty = new Buffer(32);
-        empty.fill(0);
-        fromHex.copy(empty);
-        fromHex = empty;
+        let empty = new Buffer(32)
+        empty.fill(0)
+        fromHex.copy(empty)
+        fromHex = empty
     }
 
-    return exports.reverseBuffer(fromHex);
-};
+    return exports.reverseBuffer(fromHex)
+}
 
-exports.hexFromReversedBuffer = function (buffer) {
-    return exports.reverseBuffer(buffer).toString('hex');
-};
+exports.hexFromReversedBuffer = buffer => {
+    return exports.reverseBuffer(buffer).toString('hex')
+}
 
 
 /*
  Defined in bitcoin protocol here:
  https://en.bitcoin.it/wiki/Protocol_specification#Variable_length_integer
  */
-exports.varIntBuffer = function (n) {
-    if (n < 0xfd)
-        return new Buffer([n]);
-    else if (n < 0xffff) {
-        var buff = new Buffer(3);
-        buff[0] = 0xfd;
-        buff.writeUInt16LE(n, 1);
-        return buff;
+exports.varIntBuffer = n => {
+    if (n < 0xfd) {
+        return new Buffer([n])
+    } else if (n < 0xffff) {
+        let buff = new Buffer(3)
+        buff[0] = 0xfd
+        buff.writeUInt16LE(n, 1)
+        return buff
+    } else if (n < 0xffffffff) {
+        let buff = new Buffer(5)
+        buff[0] = 0xfe
+        buff.writeUInt32LE(n, 1)
+        return buff
+    } else {
+        let buff = new Buffer(9)
+        buff[0] = 0xff
+        exports.packUInt16LE(n).copy(buff, 1)
+        return buff
     }
-    else if (n < 0xffffffff) {
-        var buff = new Buffer(5);
-        buff[0] = 0xfe;
-        buff.writeUInt32LE(n, 1);
-        return buff;
-    }
-    else {
-        var buff = new Buffer(9);
-        buff[0] = 0xff;
-        exports.packUInt16LE(n).copy(buff, 1);
-        return buff;
-    }
-};
+}
 
-exports.varStringBuffer = function (string) {
-    var strBuff = new Buffer(string);
-    return new Buffer.concat([exports.varIntBuffer(strBuff.length), strBuff]);
-};
+exports.varStringBuffer = string => {
+    let strBuff = new Buffer(string)
+    return new Buffer.concat([exports.varIntBuffer(strBuff.length), strBuff])
+}
 
 /*
  "serialized CScript" formatting as defined here:
@@ -106,264 +108,273 @@ exports.varStringBuffer = function (string) {
  Used to format height and date when putting into script signature:
  https://en.bitcoin.it/wiki/Script
  */
-exports.serializeNumber = function (n) {
-
-    /* Old version that is bugged
-     if (n < 0xfd){
-     var buff = new Buffer(2);
-     buff[0] = 0x1;
-     buff.writeUInt8(n, 1);
-     return buff;
-     }
-     else if (n <= 0xffff){
-     var buff = new Buffer(4);
-     buff[0] = 0x3;
-     buff.writeUInt16LE(n, 1);
-     return buff;
-     }
-     else if (n <= 0xffffffff){
-     var buff = new Buffer(5);
-     buff[0] = 0x4;
-     buff.writeUInt32LE(n, 1);
-     return buff;
-     }
-     else{
-     return new Buffer.concat([new Buffer([0x9]), binpack.packUInt64(n, 'little')]);
-     }*/
+exports.serializeNumber = n => {
+    // // Old version that is bugged
+    // if (n < 0xfd){
+    //     var buff = new Buffer(2);
+    //     buff[0] = 0x1;
+    //     buff.writeUInt8(n, 1);
+    //     return buff;
+    // } else if (n <= 0xffff){
+    //     var buff = new Buffer(4);
+    //     buff[0] = 0x3;
+    //     buff.writeUInt16LE(n, 1);
+    //     return buff;
+    // } else if (n <= 0xffffffff){
+    //     var buff = new Buffer(5);
+    //     buff[0] = 0x4;
+    //     buff.writeUInt32LE(n, 1);
+    //     return buff;
+    // } else{
+    //     return new Buffer.concat([new Buffer([0x9]), binpack.packUInt64(n, 'little')]);
+    // }
 
     //New version from TheSeven
-    if (n >= 1 && n <= 16) return new Buffer([0x50 + n]);
-    var l = 1;
-    var buff = new Buffer(9);
-    while (n > 0x7f) {
-        buff.writeUInt8(n & 0xff, l++);
-        n >>= 8;
+    if (n >= 1 && n <= 16) {
+        return new Buffer([0x50 + n]);
     }
-    buff.writeUInt8(l, 0);
-    buff.writeUInt8(n, l++);
-    return buff.slice(0, l);
 
-};
+    let l = 1
+    let buff = new Buffer(9)
+    while (n > 0x7f) {
+        buff.writeUInt8(n & 0xff, l++)
+        n >>= 8
+    }
+
+    buff.writeUInt8(l, 0)
+    buff.writeUInt8(n, l++)
+    return buff.slice(0, l)
+}
 
 
 /*
  Used for serializing strings used in script signature
  */
-exports.serializeString = function (s) {
-
-    if (s.length < 253)
+exports.serializeString = s => {
+    if (s.length < 253) {
         return new Buffer.concat([
             new Buffer([s.length]),
             new Buffer(s)
-        ]);
-    else if (s.length < 0x10000)
+        ])
+    } else if (s.length < 0x10000) {
         return new Buffer.concat([
             new Buffer([253]),
             exports.packUInt16LE(s.length),
             new Buffer(s)
-        ]);
-    else if (s.length < 0x100000000)
+        ])
+    } else if (s.length < 0x100000000) {
         return new Buffer.concat([
             new Buffer([254]),
             exports.packUInt32LE(s.length),
             new Buffer(s)
-        ]);
-    else
+        ])
+    } else {
         return new Buffer.concat([
             new Buffer([255]),
             exports.packUInt16LE(s.length),
             new Buffer(s)
-        ]);
-};
+        ])
+    }
+}
 
 
-exports.packUInt16LE = function (num) {
-    var buff = new Buffer(2);
-    buff.writeUInt16LE(num, 0);
-    return buff;
-};
-exports.packInt32LE = function (num) {
-    var buff = new Buffer(4);
-    buff.writeInt32LE(num, 0);
-    return buff;
-};
-exports.packInt32BE = function (num) {
-    var buff = new Buffer(4);
-    buff.writeInt32BE(num, 0);
-    return buff;
-};
-exports.packUInt32LE = function (num) {
-    var buff = new Buffer(4);
-    buff.writeUInt32LE(num, 0);
-    return buff;
-};
-exports.packUInt32BE = function (num) {
-    var buff = new Buffer(4);
-    buff.writeUInt32BE(num, 0);
-    return buff;
-};
-exports.packInt64LE = function (num) {
-    var buff = new Buffer(8);
-    buff.writeUInt32LE(num % Math.pow(2, 32), 0);
-    buff.writeUInt32LE(Math.floor(num / Math.pow(2, 32)), 4);
-    return buff;
-};
+exports.packUInt16LE = num => {
+    let buff = new Buffer(2)
+    buff.writeUInt16LE(num, 0)
+    return buff
+}
+
+exports.packInt32LE = num => {
+    let buff = new Buffer(4)
+    buff.writeInt32LE(num, 0)
+    return buff
+}
+
+exports.packInt32BE = num => {
+    let buff = new Buffer(4)
+    buff.writeInt32BE(num, 0)
+    return buff
+}
+
+exports.packUInt32LE = num => {
+    let buff = new Buffer(4)
+    buff.writeUInt32LE(num, 0)
+    return buff
+}
+
+exports.packUInt32BE = num => {
+    let buff = new Buffer(4)
+    buff.writeUInt32BE(num, 0)
+    return buff
+}
+
+exports.packInt64LE = num => {
+    let buff = new Buffer(8)
+    buff.writeUInt32LE(num % Math.pow(2, 32), 0)
+    buff.writeUInt32LE(Math.floor(num / Math.pow(2, 32)), 4)
+    return buff
+}
 
 
 /*
  An exact copy of python's range feature. Written by Tadeck:
  http://stackoverflow.com/a/8273091
  */
-exports.range = function (start, stop, step) {
+exports.range = (start, stop, step) => {
     if (typeof stop === 'undefined') {
-        stop = start;
-        start = 0;
+        stop = start
+        start = 0
     }
+
     if (typeof step === 'undefined') {
-        step = 1;
+        step = 1
     }
+
     if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
-        return [];
+        return []
     }
-    var result = [];
-    for (var i = start; step > 0 ? i < stop : i > stop; i += step) {
-        result.push(i);
+
+    let result = []
+    for (let i = start; step > 0 ? i < stop : i > stop; i += step) {
+        result.push(i)
     }
-    return result;
-};
+
+    return result
+}
 
 
 /*
  For POS coins - used to format wallet address for use in generation transaction's output
  */
-exports.pubkeyToScript = function (key) {
+exports.pubkeyToScript = key => {
     if (key.length !== 66) {
-        console.error('Invalid pubkey: ' + key);
-        throw new Error();
+        console.error('Invalid pubkey: ' + key)
+        throw new Error()
     }
-    var pubkey = new Buffer(35);
-    pubkey[0] = 0x21;
-    pubkey[34] = 0xac;
-    new Buffer(key, 'hex').copy(pubkey, 1);
-    return pubkey;
-};
+
+    let pubkey = new Buffer(35)
+    pubkey[0] = 0x21
+    pubkey[34] = 0xac
+    new Buffer(key, 'hex').copy(pubkey, 1)
+    return pubkey
+}
 
 
-exports.miningKeyToScript = function (key) {
-    var keyBuffer = new Buffer(key, 'hex');
-    return new Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), keyBuffer, new Buffer([0x88, 0xac])]);
-};
+exports.miningKeyToScript = key => {
+    let keyBuffer = new Buffer(key, 'hex')
+    return new Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), keyBuffer, new Buffer([0x88, 0xac])])
+}
 
 /*
  For POW coins - used to format wallet address for use in generation transaction's output
  */
-exports.addressToScript = function (addr) {
-
-    var decoded = base58.decode(addr);
+exports.addressToScript = addr => {
+    let decoded = base58.decode(addr)
 
     if (decoded.length !== 25 && decoded.length !== 26) {
-        console.error('invalid address length for ' + addr);
-        throw new Error();
+        console.error('invalid address length for ' + addr)
+        throw new Error()
     }
 
     if (!decoded) {
-        console.error('base58 decode failed for ' + addr);
-        throw new Error();
+        console.error('base58 decode failed for ' + addr)
+        throw new Error()
     }
 
-    var pubkey = decoded.slice(1, -4);
+    let pubkey = decoded.slice(1, -4)
 
-    return new Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
-};
+    return new Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])])
+}
 
 
-exports.getReadableHashRateString = function (hashrate) {
-    var i = -1;
-    var byteUnits = [' KH', ' MH', ' GH', ' TH', ' PH'];
+exports.getReadableHashRateString = hashrate => {
+    let i = -1
+    let byteUnits = [' KH', ' MH', ' GH', ' TH', ' PH']
     do {
-        hashrate = hashrate / 1024;
-        i++;
-    } while (hashrate > 1024);
-    return hashrate.toFixed(2) + byteUnits[i];
-};
+        hashrate = hashrate / 1024
+        i++
+    } while (hashrate > 1024)
+
+    return hashrate.toFixed(2) + byteUnits[i]
+}
 
 
-//Creates a non-truncated max difficulty (diff1) by bitwise right-shifting the max value of a uint256
-exports.shiftMax256Right = function (shiftRight) {
-
+// Creates a non-truncated max difficulty (diff1) by bitwise right-shifting the max value of a uint256
+exports.shiftMax256Right = shiftRight => {
     //Max value uint256 (an array of ones representing 256 enabled bits)
-    var arr256 = Array.apply(null, new Array(256)).map(Number.prototype.valueOf, 1);
+    let arr256 = Array.apply(null, new Array(256)).map(Number.prototype.valueOf, 1)
 
     //An array of zero bits for how far the max uint256 is shifted right
-    var arrLeft = Array.apply(null, new Array(shiftRight)).map(Number.prototype.valueOf, 0);
+    let arrLeft = Array.apply(null, new Array(shiftRight)).map(Number.prototype.valueOf, 0)
 
     //Add zero bits to uint256 and remove the bits shifted out
-    arr256 = arrLeft.concat(arr256).slice(0, 256);
+    arr256 = arrLeft.concat(arr256).slice(0, 256)
 
     //An array of bytes to convert the bits to, 8 bits in a byte so length will be 32
-    var octets = [];
+    let octets = []
 
-    for (var i = 0; i < 32; i++) {
-
-        octets[i] = 0;
+    for (let i = 0; i < 32; i++) {
+        octets[i] = 0
 
         //The 8 bits for this byte
-        var bits = arr256.slice(i * 8, i * 8 + 8);
+        let bits = arr256.slice(i * 8, i * 8 + 8)
 
         //Bit math to add the bits into a byte
-        for (var f = 0; f < bits.length; f++) {
-            var multiplier = Math.pow(2, f);
-            octets[i] += bits[f] * multiplier;
+        for (let f = 0; f < bits.length; f++) {
+            let multiplier = Math.pow(2, f)
+            octets[i] += bits[f] * multiplier
         }
-
     }
 
-    return new Buffer(octets);
-};
+    return new Buffer(octets)
+}
 
 
-exports.bufferToCompactBits = function (startingBuff) {
-    var bigNum = bignum.fromBuffer(startingBuff);
-    var buff = bigNum.toBuffer();
+exports.bufferToCompactBits = startingBuff => {
+    let bigNum = bignum.fromBuffer(startingBuff)
+    let buff = bigNum.toBuffer()
 
-    buff = buff.readUInt8(0) > 0x7f ? Buffer.concat([new Buffer([0x00]), buff]) : buff;
+    buff = buff.readUInt8(0) > 0x7f ? Buffer.concat([new Buffer([0x00]), buff]) : buff
 
-    buff = new Buffer.concat([new Buffer([buff.length]), buff]);
-    return compact = buff.slice(0, 4);
-};
+    buff = new Buffer.concat([new Buffer([buff.length]), buff])
+    return compact = buff.slice(0, 4)
+}
 
 /*
  Used to convert getblocktemplate bits field into target if target is not included.
  More info: https://en.bitcoin.it/wiki/Target
  */
-
-exports.bignumFromBitsBuffer = function (bitsBuff) {
-    var numBytes = bitsBuff.readUInt8(0);
-    var bigBits = bignum.fromBuffer(bitsBuff.slice(1));
-    var target = bigBits.mul(
+exports.bignumFromBitsBuffer = bitsBuff => {
+    let numBytes = bitsBuff.readUInt8(0)
+    let bigBits = bignum.fromBuffer(bitsBuff.slice(1))
+    let target = bigBits.mul(
         bignum(2).pow(
-            bignum(8).mul(
-                numBytes - 3
-            )
+            bignum(8).mul(numBytes - 3)
         )
-    );
-    return target;
+    )
+
+    return target
+}
+
+exports.bignumFromBitsHex = bitsString => {
+    return exports.bignumFromBitsBuffer(
+        new Buffer(bitsString, 'hex')
+    )
+}
+
+exports.convertBitsToBuff = bitsBuff => {
+    let target = exports.bignumFromBitsBuffer(bitsBuff)
+    let resultBuff = target.toBuffer()
+    let buff256 = new Buffer(32)
+    buff256.fill(0)
+    resultBuff.copy(buff256, buff256.length - resultBuff.length)
+    return buff256
 };
 
-exports.bignumFromBitsHex = function (bitsString) {
-    var bitsBuff = new Buffer(bitsString, 'hex');
-    return exports.bignumFromBitsBuffer(bitsBuff);
-};
-
-exports.convertBitsToBuff = function (bitsBuff) {
-    var target = exports.bignumFromBitsBuffer(bitsBuff);
-    var resultBuff = target.toBuffer();
-    var buff256 = new Buffer(32);
-    buff256.fill(0);
-    resultBuff.copy(buff256, buff256.length - resultBuff.length);
-    return buff256;
-};
-
-exports.getTruncatedDiff = function (shift) {
-    return exports.convertBitsToBuff(exports.bufferToCompactBits(exports.shiftMax256Right(shift)));
-};
+exports.getTruncatedDiff = shift => {
+    return exports.convertBitsToBuff(
+        exports.bufferToCompactBits(
+            exports.shiftMax256Right(shift)
+        )
+    )
+}


### PR DESCRIPTION
nTime is coming through as a reverse buffer and is properly being
parsed, but not properly being converted to an integer. Because of this,
the checks that follow could never be triggered. This change converts
the ntime buffer to a string before running it through parseInt. In
addition, an isNaN check was added for additional safety.